### PR TITLE
Add AIData description property to class

### DIFF
--- a/src/GS1/AIData.php
+++ b/src/GS1/AIData.php
@@ -19,6 +19,7 @@ class AIData
     private int $minLength;
     private int $maxLength;
     private bool $checksum;
+    private string $description;
 
     /**
      * Constructor creating an entry for an AI.


### PR DESCRIPTION
Add the description string as a property to the AIData class, as later versions of PHP triggers a deprecation warning for dynamic properties.